### PR TITLE
Support PHP 5.5.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mysql-queue
-Laravel 4.2 Mysql Queue 
+Laravel 4.2 Mysql Queue handler package, since [the original package[(https://github.com/ismael-gonzalez/mysql-queue) seem to be abandoned.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # mysql-queue
 Laravel 4.2 Mysql Queue 
+
+# Installation
+
+Open your `composer.json` to modifiy some config, then remove `"miniminum-stability": "stable"` if exists.
+
+Add this repository to your `composer.json`.
+```json
+"repositories": [
+  {
+    "type": "git",
+    "url":  "https://github.com/matriphe/mysql-queue.git"
+  }
+],
+```
+Run this command to pull and install the package.
+```console
+composer require ismael-gonzalez/mysql-queue:dev-master
+```
+
+# Configuration
+
+Open `app/config/app.php` and add the service provider in the `providers` section.
+```php
+'Mysql\Queue\MysqlQueueServiceProvider',
+```
+Open `app/config/queue.php` and add this config in `connections` section.
+```php
+'mysql' => array(
+  'driver' => 'mysql',
+  'table' => 'jobs',
+  'default' => 'default',
+),
+```
+Set the default driver to `mysql`.
+
+# Migration
+
+Copy file from `vendor/ismael-gonzalez/mysql-queue/src/Migrations/create_jobs_table.php` to `app/database/migrations` using this command.
+```console
+cp vendor/ismael-gonzalez/mysql-queue/src/Migrations/create_jobs_table.php app/database/migrations/$(date +"%Y_%m_%d_%H%M%S")_create_jobs_table.php
+```
+Execute migration.
+```console
+php artisan migrate
+```
+# Done
+
+Done! Yay!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mysql-queue
-Laravel 4.2 Mysql Queue handler package, since [the original package[(https://github.com/ismael-gonzalez/mysql-queue) seem to be abandoned.
+Laravel 4.2 Mysql Queue handler package, since [the original package](https://github.com/ismael-gonzalez/mysql-queue) seem to be abandoned.
 
 # Installation
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=5.5.9",
         "illuminate/support": "~4.0",
         "illuminate/console": "~4.0"
     },

--- a/src/MysqlQueue.php
+++ b/src/MysqlQueue.php
@@ -98,6 +98,7 @@ class MysqlQueue extends Queue implements QueueInterface{
             ->first();
 
     if(!is_null($job)){
+      $job = (array) $job;
       DB::table($this->table)->where('id', $job['id'])->update([
         'status' => MysqlQueueJob::STATUS_STARTED, 'time_started' => date('Y-m-d H:i:s'),
       ]);


### PR DESCRIPTION
Since I used this package on my project that run on very old Laravel 4.2 with PHP 5.5.9, I made a changes so somebody that have same situation could use this package.

On this pull request, I did some changes:

- Lower the PHP version to 5.5.9 to support old project that still running on PHP >= 5.5.9.
- Cast the `$job` object to array to match the `where` statement.
- Update readme by adding installation and configuration instruction.